### PR TITLE
Added Getters to expose main and replica *sql.DB connections

### DIFF
--- a/morphling.go
+++ b/morphling.go
@@ -22,6 +22,16 @@ type DB struct {
 	replica *sql.DB
 }
 
+// Returns the underlying *sql.DB associated with the main instance
+func (db *DB) Main() *sql.DB {
+	return db.main
+}
+
+// Returns the underlying *sql.DB associated with the replica instance
+func (db *DB) Replica() *sql.DB {
+	return db.replica
+}
+
 // Open opens master and slave database connection
 func Open(driverName, dataSourceMainStr, dataSourceReplicaStr string) (*DB, error) {
 	Morphling := DB{}


### PR DESCRIPTION
I would like to have these connections exposed so that my other libraries which use the standard lib *sql.DB can continue to work.